### PR TITLE
Update Deal.php -> added setDealStatus()

### DIFF
--- a/lib/GetCourse/Deal.php
+++ b/lib/GetCourse/Deal.php
@@ -20,11 +20,21 @@ class Deal extends User
 
 	/**
 	 * Номер заказа
-	 * @param $email
+	 * @param $deal_number
 	 * @return $this
 	 */
 	public function setDealNumber($deal_number) {
 		$this->deal['deal_number'] = $deal_number;
+		return $this;
+	}
+	
+	/**
+	 * Статус заказа
+	 * @param $deal_status
+	 * @return $this
+	 */
+	public function setDealStatus($deal_status) {
+		$this->deal['deal_status'] = $deal_status;
 		return $this;
 	}
 


### PR DESCRIPTION
1. Добавлен метод setDealStatus() для указания "Статус заказа" (обязательное поле).
2. Исправлена опечатка в описании PHPDoc к методу setDealNumber(): @param $email -> @param $deal_number.