### PR TITLE
Новый метод setCustomDomain

### DIFF
--- a/lib/GetCourse/core/Model.php
+++ b/lib/GetCourse/core/Model.php
@@ -24,6 +24,11 @@ class Model
 	 * Название аккаунта GetCourse
 	 */
 	private static $accountName = '';
+	/**
+	 * Домен (будет использоваться вместо account_name.getcourse.ru)
+	 * Без https://, без `/` в конце
+	 */
+	private static string $customDomain = '';
 
 	public static function setAccessToken($accessToken)	{
 		self::$accessToken = $accessToken;
@@ -32,10 +37,17 @@ class Model
 	public static function setAccountName($accountName)	{
 		self::$accountName = $accountName;
 	}
+	
+	public static function setCustomDomain($domain)	{
+		self::$customDomain = $domain;
+	}
 
 	public static function getUrl() {
-		if(!self::$accountName) {
-			throw new \Exception("Account name not supplied");
+		if(!self::$accountName && !self::$customDomain) {
+			throw new \Exception("Account name and Domain not supplied");
+		}
+		if (self::$customDomain) {
+			return 'https://' . self::$customDomain . '/pl/api';
 		}
 		return 'https://' . self::$accountName . '.getcourse.ru/pl/api/';
 	}

--- a/lib/GetCourse/core/Model.php
+++ b/lib/GetCourse/core/Model.php
@@ -47,7 +47,7 @@ class Model
 			throw new \Exception("Account name and Domain not supplied");
 		}
 		if (self::$customDomain) {
-			return 'https://' . self::$customDomain . '/pl/api';
+			return 'https://' . self::$customDomain . '/pl/api/';
 		}
 		return 'https://' . self::$accountName . '.getcourse.ru/pl/api/';
 	}

--- a/sample/dealadd.php
+++ b/sample/dealadd.php
@@ -9,6 +9,8 @@ $deal = new \GetCourse\Deal();
 
 // Замените на ваш аккаунт
 $deal::setAccountName('account_name');
+// или укажите свой домен, если в аккаунте настроен редирект с your_account.getcourse.ru на ваш домен my-domain.ru
+// $user::setCustomDomain('my-domain.ru')
 // Замените токен на сгенерированный вашим аккаунтом (http://{your_account}.getcourse.ru/saas/account/api)
 $deal::setAccessToken('secret_key');
 

--- a/sample/useradd.php
+++ b/sample/useradd.php
@@ -9,6 +9,8 @@ $user = new \GetCourse\User();
 
 // Замените на ваш аккаунт
 $user::setAccountName('account_name');
+// или укажите свой домен, если в аккаунте настроен редирект с your_account.getcourse.ru на ваш домен my-domain.ru
+// $user::setCustomDomain('my-domain.ru')
 // Замените токен на сгенерированный вашим аккаунтом (http://{your_account}.getcourse.ru/saas/account/api)
 $user::setAccessToken('secret_key');
 


### PR DESCRIPTION
В документации указано

> Обратите внимание: если в вашем аккаунте настроен принудительный редирект с системного адреса аккаунта «ваш_аккаунт.getcourse.ru» на добавленный домен «ваш_домен.ru», и вы хотите использовать методы API в формате cURL — необходимо использовать домен «ваш_домен.ru» вместо «ваш_аккаунт.getcourse.ru» в адресе, по которому происходит запрос

В настоящий момент SDK не позволяет использовать добавленный домен.

Этот PR добавляет новый метод `setCustomDomain()` и изменяет метод формирования URL.

Плюс обновил примеры использования.